### PR TITLE
Added primary key length for mysql

### DIFF
--- a/db/sql/session.php
+++ b/db/sql/session.php
@@ -187,7 +187,7 @@ class Session extends Mapper {
 					$tab.$db->quotekey('ip').' VARCHAR(45),'.$eol.
 					$tab.$db->quotekey('agent').' VARCHAR(300),'.$eol.
 					$tab.$db->quotekey('stamp').' INTEGER,'.$eol.
-					$tab.'PRIMARY KEY ('.$db->quotekey($sqlsrv?'id':'session_id').')'.$eol.
+					$tab.'PRIMARY KEY ('.$db->quotekey($sqlsrv?'id':'session_id').($db->driver()=='mysql'?'(20)':'').')'.$eol.
 				($sqlsrv?',CONSTRAINT [UK_session_id] UNIQUE(session_id)':'').
 				');'
 			);


### PR DESCRIPTION
This table fails to create if your default charset is utf8mb4 for your database because the key length of 255 is too long. This should fix it.