### PR TITLE
Adds support for geometry fields in SQL mappers

### DIFF
--- a/db/sql/mapper.php
+++ b/db/sql/mapper.php
@@ -464,7 +464,7 @@ class Mapper extends \DB\Cursor {
 			}
 			if ($field['changed'] && $key!=$inc) {
 				$fields.=($actr?',':'').$this->db->quotekey($key);
-				$values.=($actr?',':'').'?';
+				$values.=($actr?',':'').($field['type'] === 'geometry' ? 'ST_GeomFromText(?)' : '?');
 				$args[$actr+1]=[$field['value'],$field['pdo_type']];
 				++$actr;
 				$ckeys[]=$key;
@@ -527,7 +527,7 @@ class Mapper extends \DB\Cursor {
 			return $this;
 		foreach ($this->fields as $key=>$field)
 			if ($field['changed']) {
-				$pairs.=($pairs?',':'').$this->db->quotekey($key).'=?';
+				$pairs.=($pairs?',':'').$this->db->quotekey($key).($field['type'] === 'geometry' ? '=ST_GeomFromText(?)' : '=?');
 				$args[++$ctr]=[$field['value'],$field['pdo_type']];
 			}
 		if ($pairs) {
@@ -566,7 +566,7 @@ class Mapper extends \DB\Cursor {
 		$pairs='';
 		foreach ($this->fields as $key=>$field)
 			if ($field['changed']) {
-				$pairs.=($pairs?',':'').$this->db->quotekey($key).'=?';
+				$pairs.=($pairs?',':'').$this->db->quotekey($key).($field['type'] === 'geometry' ? '=ST_GeomFromText(?)' : '=?');
 				$args[++$ctr]=[$field['value'],$field['pdo_type']];
 			}
 		if ($filter)


### PR DESCRIPTION
Currently its not possible to insert/update geometry fields with a SQL mapper. 

This adds support for this

How to use: 

```
$this->User_Mapper->position =  'POINT (30 10)';
$this->User_Mapper->save();
```

This also works with other geometry types: 

`$this->User_Mapper->position =  'LINESTRING(2 1, 6 6)';`

`$this->User_Mapper->position =  'POLYGON((0 5, 2 5, 2 7, 0 7, 0 5))';`

Retrieving geometry information can be done using a virtual field

```
$this->User_Mapper->distance = "ST_Distance(POINT(2,1), position)";
$this->User_Mapper->load(['id = ?', 1]);
echo $this->User_Mapper->distance;
```