### PR TITLE
Enable instantiating logger with format-string

### DIFF
--- a/log.php
+++ b/log.php
@@ -23,9 +23,14 @@
 //! Custom logger
 class Log {
 
+	// default format string
+	const DEFAULT_FORMAT = 'r';
+
 	protected
 		//! File name
-		$file;
+		$file,
+		//! format string
+		$format;
 
 	/**
 	*	Write specified text to log file
@@ -33,12 +38,13 @@ class Log {
 	*	@param $text string
 	*	@param $format string
 	**/
-	function write($text,$format='r') {
+	function write($text,$format=FALSE) {
 		$fw=Base::instance();
+		$current_format = (!$format) ? $this->format : $format;
 		foreach (preg_split('/\r?\n|\r/',trim($text)) as $line)
 			$fw->write(
 				$this->file,
-				date($format).
+				date($current_format).
 				(isset($_SERVER['REMOTE_ADDR'])?
 					(' ['.$_SERVER['REMOTE_ADDR'].
 					(($fwd=filter_var($fw->get('HEADERS.X-Forwarded-For'),
@@ -60,12 +66,14 @@ class Log {
 	/**
 	*	Instantiate class
 	*	@param $file string
+	*	@param $format string
 	**/
-	function __construct($file) {
+	function __construct($file,$format=FALSE) {
 		$fw=Base::instance();
 		if (!is_dir($dir=$fw->LOGS))
 			mkdir($dir,Base::MODE,TRUE);
 		$this->file=$dir.$file;
+		$this->format = (!$format) ? self::DEFAULT_FORMAT : $format;
 	}
 
 }


### PR DESCRIPTION
Hi there @ FatFreeFramework,
let me first say THANK YOU for such a great piece of software!

I am currently working on a "big" cronjob, that uses a lot of logging. As I prefer to use a different format string for date/time, it kind of annoyed me, to add my custom format-string to every write-method-call.

So I gave it a shot and extended the log-class with a feature to instantiate it with a desired format-string that will be used for all subsequent write-method-calls that don't pass a format-string.

As far as I have tested, this retains full backward compatibilty, while just adding the new feature.

If you find it useful, maybe you can merge it.

Thanks again for FatFreeFramework,
Manfred