### PR TITLE
Use the same string replacement for keys in cache getter as setter

### DIFF
--- a/base.php
+++ b/base.php
@@ -2648,7 +2648,8 @@ class Cache extends Prefab {
 				$raw=xcache_get($ndx);
 				break;
 			case 'folder':
-				$raw=$fw->read($parts[1].$ndx);
+				$raw=$fw->read($parts[1]
+					.str_replace(['/','\\'],'',$ndx));
 				break;
 		}
 		if (!empty($raw)) {


### PR DESCRIPTION
This is a bit of a band-aid approach to deal with a specific use case for myself. What should eventually happen is a reevaluation of all `is_file`, `write` and `read` calls in `base.php` to have the filename strings always get passed through the `fixslashes` method before checking the filesystem to ensure consistent and filesystem-safe keys.