### PR TITLE
Fix `isprivate()` method.

### DIFF
--- a/audit.php
+++ b/audit.php
@@ -77,8 +77,8 @@ class Audit extends Prefab {
 	*	@param $addr string
 	**/
 	function isprivate($addr) {
-		return !(bool)filter_var($addr,FILTER_VALIDATE_IP,
-			FILTER_FLAG_IPV4|FILTER_FLAG_IPV6|FILTER_FLAG_NO_PRIV_RANGE);
+		return (bool)filter_var($addr, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | FILTER_FLAG_IPV6)
+			&& !(bool)filter_var($addr, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE);
 	}
 
 	/**


### PR DESCRIPTION
Fix incorrect usage of the `FILTER_FLAG_NO_PRIV_RANGE ` flag in the `filter_var()` function.

The `FILTER_FLAG_NO_PRIV_RANGE ` flag is used to **EXCLUDE** private IP ranges. But in the code, the flag is used with the `FILTER_VALIDATE_IP ` filter, which actually **VALIDATES** the IP address. As a result, the method returns the opposite result of what is intended.
So we need to change the usage of the `FILTER_FLAG_NO_PRIV_RANGE ` flag. Instead of using it with the `FILTER_VALIDATE_IP ` filter, we should use it with the `FILTER_FLAG_NO_PRIV_RANGE  `flag **DIRECTLY**.

By using old(bugged) function we have:

```
echo isprivate(''); // TRUE
echo isprivate(' '); // TRUE
echo isprivate(null); // TRUE

echo isprivate('23.6.32.11'); // FALSE
echo isprivate('40.2.110.1'); // FALSE
echo isprivate('127.0.0.1'); // FALSE

echo isprivate('192.168.3.4'); // TRUE
echo isprivate('10.0.0.0'); // TRUE
echo isprivate('172.31.255.255'); // TRUE
```

Now by using new(fixed) function we have:

```
echo isprivate(''); // FALSE
echo isprivate(' '); // FALSE
echo isprivate(null); // FALSE

echo isprivate('23.6.32.11'); // FALSE
echo isprivate('40.2.110.1'); // FALSE
echo isprivate('127.0.0.1'); // FALSE

echo isprivate('192.168.3.4'); // TRUE
echo isprivate('10.0.0.0'); // TRUE
echo isprivate('172.31.255.255'); // TRUE
```