### PR TITLE
cursor.php load method does not return an array

### DIFF
--- a/db/cursor.php
+++ b/db/cursor.php
@@ -169,7 +169,7 @@ abstract class Cursor extends \Magic implements \IteratorAggregate {
 
 	/**
 	*	Map to first record that matches criteria
-	*	@return array|FALSE
+	*	@return \DB\SQL\Mapper|FALSE
 	*	@param $filter string|array
 	*	@param $options array
 	*	@param $ttl int


### PR DESCRIPTION
The load method does not return an array. It returns an object (\DB\SQL\Mapper).