### PR TITLE
fix http_build_query()

### DIFF
--- a/web/oauth2.php
+++ b/web/oauth2.php
@@ -39,7 +39,7 @@ class OAuth2 extends \Magic {
 	**/
 	function uri($endpoint,$query=TRUE) {
 		return $endpoint.($query?('?'.
-				http_build_query($this->args,null,'&',$this->enc_type)):'');
+				http_build_query($this->args,'','&',$this->enc_type)):'');
 	}
 
 	/**
@@ -53,7 +53,7 @@ class OAuth2 extends \Magic {
 		$web=\Web::instance();
 		$options=[
 			'method'=>$method,
-			'content'=>http_build_query($this->args,null,'&',$this->enc_type),
+			'content'=>http_build_query($this->args,'','&',$this->enc_type),
 			'header'=>['Accept: application/json']
 		];
 		if ($token)


### PR DESCRIPTION
Fix for: http_build_query(): Passing null to parameter #2 ($numeric_prefix) of type string is deprecated