### PR TITLE
[PHP 8.4] Fixes for implicit nullability deprecation

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -247,7 +247,7 @@ class Auth {
 	*	@param $args array
 	*	@param $func callback
 	**/
-	function __construct($storage,array $args=NULL,$func=NULL) {
+	function __construct($storage,?array $args=NULL,$func=NULL) {
 		if (is_object($storage) && is_a($storage,'DB\Cursor')) {
 			$this->storage=$storage->dbtype();
 			$this->mapper=$storage;

--- a/base.php
+++ b/base.php
@@ -726,7 +726,7 @@ final class Base extends Prefab implements ArrayAccess {
 	*	@param $arg mixed
 	*	@param $stack array
 	**/
-	function stringify($arg,array $stack=NULL) {
+	function stringify($arg,?array $stack=NULL) {
 		if ($stack) {
 			foreach ($stack as $node)
 				if ($arg===$node)
@@ -1316,7 +1316,7 @@ final class Base extends Prefab implements ArrayAccess {
 	*	@param $trace array|NULL
 	*	@param $format bool
 	**/
-	function trace(array $trace=NULL,$format=TRUE) {
+	function trace(?array $trace=NULL,$format=TRUE) {
 		if (!$trace) {
 			$trace=debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
 			$frame=$trace[0];
@@ -1364,7 +1364,7 @@ final class Base extends Prefab implements ArrayAccess {
 	*	@param $trace array
 	*	@param $level int
 	**/
-	function error($code,$text='',array $trace=NULL,$level=0) {
+	function error($code,$text='',?array $trace=NULL,$level=0) {
 		$prior=$this->hive['ERROR'];
 		$header=$this->status($code);
 		$req=$this->hive['VERB'].' '.$this->hive['PATH'];
@@ -1443,7 +1443,7 @@ final class Base extends Prefab implements ArrayAccess {
 	*	@param $body string
 	**/
 	function mock($pattern,
-		array $args=NULL,array $headers=NULL,$body=NULL) {
+		?array $args=NULL,?array $headers=NULL,$body=NULL) {
 		if (!$args)
 			$args=[];
 		$types=['sync','ajax','cli'];
@@ -2929,7 +2929,7 @@ class View extends Prefab {
 	*	@param $hive array
 	*	@param $mime string
 	**/
-	protected function sandbox(array $hive=NULL,$mime=NULL) {
+	protected function sandbox(?array $hive=NULL,$mime=NULL) {
 		$fw=$this->fw;
 		$implicit=FALSE;
 		if (is_null($hive)) {
@@ -2966,7 +2966,7 @@ class View extends Prefab {
 	*	@param $hive array
 	*	@param $ttl int
 	**/
-	function render($file,$mime='text/html',array $hive=NULL,$ttl=0) {
+	function render($file,$mime='text/html',?array $hive=NULL,$ttl=0) {
 		$fw=$this->fw;
 		$cache=Cache::instance();
 		foreach ($fw->split($fw->UI) as $dir) {
@@ -3113,7 +3113,7 @@ class Preview extends View {
 	*	@param $persist bool
 	*	@param $escape bool
 	**/
-	function resolve($node,array $hive=NULL,$ttl=0,$persist=FALSE,$escape=NULL) {
+	function resolve($node,?array $hive=NULL,$ttl=0,$persist=FALSE,$escape=NULL) {
 		$hash=null;
 		$fw=$this->fw;
 		$cache=Cache::instance();
@@ -3175,7 +3175,7 @@ class Preview extends View {
 	*	@param $hive array
 	*	@param $ttl int
 	**/
-	function render($file,$mime='text/html',array $hive=NULL,$ttl=0) {
+	function render($file,$mime='text/html',?array $hive=NULL,$ttl=0) {
 		$fw=$this->fw;
 		$cache=Cache::instance();
 		if (!is_dir($tmp=$fw->TEMP))

--- a/db/cursor.php
+++ b/db/cursor.php
@@ -64,7 +64,7 @@ abstract class Cursor extends \Magic implements \IteratorAggregate {
 	*	@param $options array
 	*	@param $ttl int
 	**/
-	abstract function find($filter=NULL,array $options=NULL,$ttl=0);
+	abstract function find($filter=NULL,?array $options=NULL,$ttl=0);
 
 	/**
 	*	Count records that match criteria
@@ -73,7 +73,7 @@ abstract class Cursor extends \Magic implements \IteratorAggregate {
 	*	@param $options array
 	*	@param $ttl int
 	**/
-	abstract function count($filter=NULL,array $options=NULL,$ttl=0);
+	abstract function count($filter=NULL,?array $options=NULL,$ttl=0);
 
 	/**
 	*	Insert new record
@@ -126,7 +126,7 @@ abstract class Cursor extends \Magic implements \IteratorAggregate {
 	*	@param $options array
 	*	@param $ttl int
 	**/
-	function findone($filter=NULL,array $options=NULL,$ttl=0) {
+	function findone($filter=NULL,?array $options=NULL,$ttl=0) {
 		if (!$options)
 			$options=[];
 		// Override limit
@@ -147,7 +147,7 @@ abstract class Cursor extends \Magic implements \IteratorAggregate {
 	*	@param $bounce bool
 	**/
 	function paginate(
-		$pos=0,$size=10,$filter=NULL,array $options=NULL,$ttl=0,$bounce=TRUE) {
+		$pos=0,$size=10,$filter=NULL,?array $options=NULL,$ttl=0,$bounce=TRUE) {
 		$total=$this->count($filter,$options,$ttl);
 		$count=(int)ceil($total/$size);
 		if ($bounce)
@@ -174,7 +174,7 @@ abstract class Cursor extends \Magic implements \IteratorAggregate {
 	*	@param $options array
 	*	@param $ttl int
 	**/
-	function load($filter=NULL,array $options=NULL,$ttl=0) {
+	function load($filter=NULL,?array $options=NULL,$ttl=0) {
 		$this->reset();
 		return ($this->query=$this->find($filter,$options,$ttl)) &&
 			$this->skip(0)?$this->query[$this->ptr]:FALSE;

--- a/db/jig.php
+++ b/db/jig.php
@@ -78,7 +78,7 @@ class Jig {
 	*	@param $file string
 	*	@param $data array
 	**/
-	function write($file,array $data=NULL) {
+	function write($file,?array $data=NULL) {
 		if (!$this->dir || $this->lazy)
 			return count($this->data[$file]=$data);
 		$fw=\Base::instance();

--- a/db/jig/mapper.php
+++ b/db/jig/mapper.php
@@ -156,7 +156,7 @@ class Mapper extends \DB\Cursor {
 	*	@param $ttl int|array
 	*	@param $log bool
 	**/
-	function find($filter=NULL,array $options=NULL,$ttl=0,$log=TRUE) {
+	function find($filter=NULL,?array $options=NULL,$ttl=0,$log=TRUE) {
 		if (!$options)
 			$options=[];
 		$options+=[
@@ -352,7 +352,7 @@ class Mapper extends \DB\Cursor {
 	*	@param $options array
 	*	@param $ttl int|array
 	**/
-	function count($filter=NULL,array $options=NULL,$ttl=0) {
+	function count($filter=NULL,?array $options=NULL,$ttl=0) {
 		$now=microtime(TRUE);
 		$out=count($this->find($filter,$options,$ttl,FALSE));
 		$this->db->jot('('.sprintf('%.1f',1e3*(microtime(TRUE)-$now)).'ms) '.

--- a/db/mongo.php
+++ b/db/mongo.php
@@ -130,7 +130,7 @@ class Mongo {
 	*	@param $dbname string
 	*	@param $options array
 	**/
-	function __construct($dsn,$dbname,array $options=NULL) {
+	function __construct($dsn,$dbname,?array $options=NULL) {
 		$this->uuid=\Base::instance()->hash($this->dsn=$dsn);
 		if ($this->legacy=class_exists('\MongoClient')) {
 			$this->db=new \MongoDB(new \MongoClient($dsn,$options?:[]),$dbname);

--- a/db/mongo/mapper.php
+++ b/db/mongo/mapper.php
@@ -121,7 +121,7 @@ class Mapper extends \DB\Cursor {
 	*	@param $options array
 	*	@param $ttl int|array
 	**/
-	function select($fields=NULL,$filter=NULL,array $options=NULL,$ttl=0) {
+	function select($fields=NULL,$filter=NULL,?array $options=NULL,$ttl=0) {
 		if (!$options)
 			$options=[];
 		$options+=[
@@ -199,7 +199,7 @@ class Mapper extends \DB\Cursor {
 	*	@param $options array
 	*	@param $ttl int|array
 	**/
-	function find($filter=NULL,array $options=NULL,$ttl=0) {
+	function find($filter=NULL,?array $options=NULL,$ttl=0) {
 		if (!$options)
 			$options=[];
 		$options+=[
@@ -218,7 +218,7 @@ class Mapper extends \DB\Cursor {
 	*	@param $options array
 	*	@param $ttl int|array
 	**/
-	function count($filter=NULL,array $options=NULL,$ttl=0) {
+	function count($filter=NULL,?array $options=NULL,$ttl=0) {
 		$fw=\Base::instance();
 		$cache=\Cache::instance();
 		$tag='';

--- a/db/sql.php
+++ b/db/sql.php
@@ -535,7 +535,7 @@ class SQL {
 	*	@param $pw string
 	*	@param $options array
 	**/
-	function __construct($dsn,$user=NULL,$pw=NULL,array $options=NULL) {
+	function __construct($dsn,$user=NULL,$pw=NULL,?array $options=NULL) {
 		$fw=\Base::instance();
 		$this->uuid=$fw->hash($this->dsn=$dsn);
 		if (preg_match('/^.+?(?:dbname|database)=(.+?)(?=;|$)/is',$dsn,$parts))

--- a/db/sql/mapper.php
+++ b/db/sql/mapper.php
@@ -205,7 +205,7 @@ class Mapper extends \DB\Cursor {
 	*	@param $filter string|array
 	*	@param $options array
 	**/
-	function stringify($fields,$filter=NULL,array $options=NULL) {
+	function stringify($fields,$filter=NULL,?array $options=NULL) {
 		if (!$options)
 			$options=[];
 		$options+=[
@@ -303,7 +303,7 @@ class Mapper extends \DB\Cursor {
 	*	@param $options array
 	*	@param $ttl int|array
 	**/
-	function select($fields,$filter=NULL,array $options=NULL,$ttl=0) {
+	function select($fields,$filter=NULL,?array $options=NULL,$ttl=0) {
 		list($sql,$args)=$this->stringify($fields,$filter,$options);
 		$result=$this->db->exec($sql,$args,$ttl);
 		$out=[];
@@ -329,7 +329,7 @@ class Mapper extends \DB\Cursor {
 	*	@param $options array
 	*	@param $ttl int|array
 	**/
-	function find($filter=NULL,array $options=NULL,$ttl=0) {
+	function find($filter=NULL,?array $options=NULL,$ttl=0) {
 		if (!$options)
 			$options=[];
 		$options+=[
@@ -355,7 +355,7 @@ class Mapper extends \DB\Cursor {
 	*	@param $options array
 	*	@param $ttl int|array
 	**/
-	function count($filter=NULL,array $options=NULL,$ttl=0) {
+	function count($filter=NULL,?array $options=NULL,$ttl=0) {
 		$adhoc=[];
 		// with grouping involved, we need to wrap the actualy query and count the results
 		if ($subquery_mode=($options && !empty($options['group']))) {

--- a/web.php
+++ b/web.php
@@ -592,7 +592,7 @@ class Web extends Prefab {
 	*	@param $url string
 	*	@param $options array
 	**/
-	function request($url,array $options=NULL) {
+	function request($url,?array $options=NULL) {
 		$fw=Base::instance();
 		$parts=parse_url($url);
 		if (empty($parts['scheme'])) {

--- a/web/openid.php
+++ b/web/openid.php
@@ -141,7 +141,7 @@ class OpenID extends \Magic {
 	*	@param $attr array
 	*	@param $reqd string|array
 	**/
-	function auth($proxy=NULL,$attr=[],array $reqd=NULL) {
+	function auth($proxy=NULL,$attr=[],?array $reqd=NULL) {
 		$fw=\Base::instance();
 		$root=$fw->SCHEME.'://'.$fw->HOST;
 		if (empty($this->args['trust_root']))


### PR DESCRIPTION
Fixes all issues that emits a deprecation notice on PHP 8.4.

See:
 - [RFC](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)
 - [PHP 8.4: Implicitly nullable parameter declarations deprecated](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated)