### PR TITLE
When querying the fields for a table, the schema is missing

### DIFF
--- a/db/sql.php
+++ b/db/sql.php
@@ -375,6 +375,7 @@ class SQL {
 							('AND K.TABLE_CATALOG=T.TABLE_CATALOG '):'').
 				'WHERE '.
 					'C.TABLE_NAME='.$this->quote($table).
+					(empty($schema) ?: ' AND C.TABLE_SCHEMA='.$this->quote($schema)).
 					($this->dbname?
 						(' AND C.TABLE_CATALOG='.
 							$this->quote($this->dbname)):''),


### PR DESCRIPTION
We have more than one schema in a PGSQL database. This causes problems if tables with the same name exist in different schemas that have different fields.
The problem is that the schema is not used when determining the fields.
I have now added the schema to the WHERE clause. Unfortunately, I can only test it with PGSQL at the moment.