### PR TITLE
fix websocket handlers call

### DIFF
--- a/cli/ws.php
+++ b/cli/ws.php
@@ -399,8 +399,8 @@ class Agent {
 		if (is_bool($server->write($this->socket,$buf)))
 			return FALSE;
 		if (!in_array($op,[WS::Pong,WS::Close]) &&
-			isset($this->server->events['send']) &&
-			is_callable($func=$this->server->events['send']))
+			isset($this->server->events()['send']) &&
+			is_callable($func=$this->server->events()['send']))
 			$func($this,$op,$data);
 		return $data;
 	}
@@ -446,8 +446,8 @@ class Agent {
 			case WS::Text:
 				$data=trim($data);
 			case WS::Binary:
-				if (isset($this->server->events['receive']) &&
-					is_callable($func=$this->server->events['receive']))
+				if (isset($this->server->events()['receive']) &&
+					is_callable($func=$this->server->events()['receive']))
 					$func($this,$op,$data);
 				break;
 			}
@@ -459,8 +459,8 @@ class Agent {
 	*	Destroy object
 	**/
 	function __destruct() {
-		if (isset($this->server->events['disconnect']) &&
-			is_callable($func=$this->server->events['disconnect']))
+		if (isset($this->server->events()['disconnect']) &&
+			is_callable($func=$this->server->events()['disconnect']))
 			$func($this);
 	}
 
@@ -479,8 +479,8 @@ class Agent {
 		$this->uri=$uri;
 		$this->headers=$hdrs;
 
-		if (isset($server->events['connect']) &&
-			is_callable($func=$server->events['connect']))
+		if (isset($server->events()['connect']) &&
+			is_callable($func=$server->events()['connect']))
 			$func($this);
 	}
 


### PR DESCRIPTION
ISSUE WITH WEBSOCKET HANDLERS

Only the start, idle, and stop handlers are being fired. None of the events that the Agent class is trying to call are working because PHP is attempting to access the protected property 'events' directly instead of calling the method to retrieve them.