### PR TITLE
Adding new mac address validation for audit class

### DIFF
--- a/audit.php
+++ b/audit.php
@@ -196,7 +196,7 @@ class Audit extends Prefab {
      **/
     function mac($addr) {
         return (bool)filter_var($addr,FILTER_VALIDATE_MAC)
-            || !preg_match('/^([0-9a-f]{2}:){3}ff:fe(:[0-9a-f]{2}){3}$/i', $addr);
+            || preg_match('/^([0-9a-f]{2}:){3}ff:fe(:[0-9a-f]{2}){3}$/i', $addr);
     }
 
 }

--- a/audit.php
+++ b/audit.php
@@ -189,4 +189,14 @@ class Audit extends Prefab {
 				'/[A-Z].*?[0-9[:punct:]]|[0-9[:punct:]].*?[A-Z]/',$str));
 	}
 
+    /**
+     *	Return TRUE if string is a valid MAC address including EUI-64 format
+     *	@return bool
+     *	@param $addr string
+     **/
+    function mac($addr) {
+        return (bool)filter_var($addr,FILTER_VALIDATE_MAC)
+            || !preg_match('/^([0-9a-f]{2}:){3}ff:fe(:[0-9a-f]{2}){3}$/i', $addr);
+    }
+
 }


### PR DESCRIPTION
The current implementation of `FILTER_VALIDATE_MAC` https://github.com/php/php-src/blob/f3feef8b931cd9c2c9ffa588d9044f077d54b9a3/ext/filter/logical_filters.c#L981 validates `MAC-48/EUI-48` formats with colon, hyphen and dot (Cisco) styles. The `mac` function adds support for `EUI-64` format.