### PR TITLE
Use the correct operator to add TABLE_SCHEMA to WHERE

### DIFF
--- a/db/sql.php
+++ b/db/sql.php
@@ -375,7 +375,7 @@ class SQL {
 							('AND K.TABLE_CATALOG=T.TABLE_CATALOG '):'').
 				'WHERE '.
 					'C.TABLE_NAME='.$this->quote($table).
-					(empty($schema) ?: ' AND C.TABLE_SCHEMA='.$this->quote($schema)).
+					(empty($schema) ? '' : ' AND C.TABLE_SCHEMA='.$this->quote($schema)).
 					($this->dbname?
 						(' AND C.TABLE_CATALOG='.
 							$this->quote($this->dbname)):''),


### PR DESCRIPTION
Hi there,

After updating to 3.9.0, my app stopped working and was throwing 500s due to a SQL Error.

```
SQLSTATE[42601]: Syntax error: 7 ERROR:  syntax error at or near "1"
LINE 1: ...CATALOG=T.TABLE_CATALOG WHERE C.TABLE_NAME='users'1 AND C.TA...
                                                             ^ [.../vendor/bcosca/fatfree-core/db/sql.php:230]
[.../vendor/bcosca/fatfree-core/db/sql.php:230] PDOStatement->execute()
[.../vendor/bcosca/fatfree-core/db/sql.php:411] DB\SQL->exec()
[.../vendor/bcosca/fatfree-core/db/sql/mapper.php:763] DB\SQL->schema()
[.../app/controllers/Page.php:8] DB\SQL\Mapper->__construct()
[.../app/controllers/Page.php:68] Page->_plzLogin()
[.../index.php:44] Base->run()
```

Looking at my PgSQL logs, I could confirm that "1" is placed where that new line introduced in https://github.com/f3-factory/fatfree-core/commit/9c7695d3291ba3a55db763a400feb562e7222471 is.

Using the `?:` operator, the line will return true ("1") since `empty($schema)` is a true-y value.
I suppose you'd want to use `? '' :` instead.
