### PR TITLE
Fix error thrown by `read()` for cache

### DIFF
--- a/base.php
+++ b/base.php
@@ -2240,9 +2240,15 @@ final class Base extends Prefab implements ArrayAccess {
 	*	@param $file string
 	*	@param $lf bool
 	**/
-	function read($file,$lf=FALSE) {
-		$out=@file_get_contents($file);
-		return $lf?preg_replace('/\r\n|\r/',"\n",$out):$out;
+	function read($file, $lf = FALSE)
+	{
+		if (!file_exists($file)) {
+			return false;
+		}
+		
+		$out = file_get_contents($file);
+
+		return $lf ? preg_replace('/\r\n|\r/', "\n", $out) : $out;
 	}
 
 	/**


### PR DESCRIPTION
As of PHP 8.0.0, @ returns the value of some expression
It was bothering me, so fixed it
![Capture](https://github.com/user-attachments/assets/196482ee-d32d-4c64-bbec-4af87f52b054)
