### PR TITLE
fix: preserve falsy string "0" in split() and cookie values

### DIFF
--- a/base.php
+++ b/base.php
@@ -469,7 +469,7 @@ final class Base extends Prefab implements ArrayAccess {
 						setcookie($parts[1],'',['expires'=>0]+$jar);
 					if ($ttl)
 						$jar['expires']=$time+$ttl;
-					setcookie($parts[1],$val?:'',$jar);
+					setcookie($parts[1],$val??'',$jar);
 				} else {
 					unset($jar['samesite']);
 					if (isset($_COOKIE[$parts[1]]))
@@ -477,7 +477,7 @@ final class Base extends Prefab implements ArrayAccess {
 							array_merge([$parts[1],''],['expire'=>0]+$jar));
 					if ($ttl)
 						$jar['expire']=$time+$ttl;
-					call_user_func_array('setcookie',[$parts[1],$val?:'']+$jar);
+					call_user_func_array('setcookie',[$parts[1],$val??'']+$jar);
 				}
 				$_COOKIE[$parts[1]]=$val;
 				return $val;
@@ -802,7 +802,7 @@ final class Base extends Prefab implements ArrayAccess {
 	**/
 	function split($str,$noempty=TRUE) {
 		return array_map('trim',
-			preg_split('/[,;|]/',$str?:'',0,$noempty?PREG_SPLIT_NO_EMPTY:0));
+			preg_split('/[,;|]/',$str??'',0,$noempty?PREG_SPLIT_NO_EMPTY:0));
 	}
 
 	/**


### PR DESCRIPTION
Fixes two falsy-value bugs where the string "0" was silently dropped:

- **split()** — Used `$str ?: ''` which treats "0" as falsy, so `split("0")` returned `[]` instead of `["0"]`. Now uses null coalescing `??`.
- **setcookie()** — Used `$val ?: ''` which drops "0" cookie values. Now uses `??` in both PHP 7.3+ and legacy code paths.