### PR TITLE
fix: guard begin() against nested transaction calls

### DIFF
--- a/db/sql.php
+++ b/db/sql.php
@@ -56,6 +56,8 @@ class SQL {
 	*	@return bool
 	**/
 	function begin() {
+		if ($this->trans)
+			return FALSE;
 		$out=$this->pdo->begintransaction();
 		$this->trans=TRUE;
 		return $out;


### PR DESCRIPTION
Calling begin() twice throws on PostgreSQL and silently no-ops on MySQL.
The $trans flag was set but never consulted, and commit()/rollback() always
reset it to FALSE — so an inner commit would incorrectly mark the outer
transaction as closed.

Now returns FALSE if a transaction is already active.