### PR TITLE
fix: narrow UA_AI pattern to avoid false positives on legitimate apps

### DIFF
--- a/audit.php
+++ b/audit.php
@@ -27,7 +27,7 @@ class Audit extends Prefab {
 	const
 		UA_Mobile='android|blackberry|phone|ipod|palm|windows\s+ce',
 		UA_Desktop='bsd|linux|os\s+[x9]|solaris|windows',
-		UA_AI='gpt|claude|mistral|oai|google-extended|perplexity|anthropic|cohere|duckassist|amazonbot|bingbot|-ai|ai-',
+		UA_AI='gpt|claude|mistral|oai|google-extended|perplexity|anthropic|cohere|duckassist|amazonbot|bingbot|ai-crawler|ai-bot|ai-spider',
 		UA_Bot='bot|crawl|slurp|spider|agent|omgili|external';
 	//@}
 


### PR DESCRIPTION
The -ai|ai- substring patterns matched any User-Agent containing those
fragments, causing false positives on legitimate apps like "safari-ai"
or "ai-enhanced".

Replaced with specific ai-crawler|ai-bot|ai-spider patterns. Known AI
crawlers (gpt, claude, mistral, oai, etc.) are unaffected.